### PR TITLE
Fix module resolution in example imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,8 @@
     </div>
     <script type="module">
       import * as THREE from "https://unpkg.com/three@0.158.0/build/three.module.js";
-      import { GLTFLoader } from "https://unpkg.com/three@0.158.0/examples/jsm/loaders/GLTFLoader.js";
-      import { OrbitControls } from "https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js";
+        import { GLTFLoader } from "https://unpkg.com/three@0.158.0/examples/jsm/loaders/GLTFLoader.js?module";
+        import { OrbitControls } from "https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js?module";
       import GUI from "https://cdn.jsdelivr.net/npm/lil-gui@0.18/+esm";
 
       let scene, camera, renderer, controls, model;


### PR DESCRIPTION
## Summary
- ensure GLTFLoader and OrbitControls imports append `?module`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686038621408832b97417a8dc1f8b3e2