### PR TITLE
Improve user instructions and debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This project aims to provide a web-based tool for designing wooden materials wit
 ## Getting Started
 
 Open `index.html` in a modern browser. Use the dropdown to switch between sample plank models.
-You can drag and drop an image onto the drop zone or use the **Upload Texture**
-button to load your own wood texture.
+You can drag and drop an image onto the drop zone or, as an alternative,
+use the **Upload Texture** button to load your own wood texture.
 
 Use the sliders to tweak roughness and metalness in real time. Click **Copy Link** to share your current design via the encoded URL parameters.
 
@@ -48,3 +48,7 @@ python3 -m http.server
 
 Once the server is running, open
 <http://localhost:8000/index.html> in your browser.
+
+Open your browser's developer console to view helpful logs when models or
+textures are loaded. If something fails to appear, these logs can help you
+troubleshoot issues.

--- a/index.html
+++ b/index.html
@@ -97,7 +97,10 @@
     <div id="ui">
       <p id="instructions">
         Select a plank model and apply your texture using drag &amp; drop or the
-        upload button.
+        <strong>Upload</strong> button. If nothing appears, run
+        <code>python3 -m http.server</code> in this folder and open
+        <code>http://localhost:8000/index.html</code>. Open the developer
+        console for detailed loading logs.
       </p>
       <section>
         <h2>Model<span class="help" data-tooltip="Choose which wood plank geometry to view">?</span></h2>
@@ -141,6 +144,8 @@
       import { OrbitControls } from "https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js?module";
       import { buildQuery, debounce } from "./src/utils.js";
       import GUI from "https://cdn.jsdelivr.net/npm/lil-gui@0.18/+esm";
+
+      console.log('Wooden Design viewer initialized');
 
       let scene, camera, renderer, controls, model;
       const params = {
@@ -242,32 +247,42 @@
 
       function loadModel(path) {
         const loader = new GLTFLoader();
-        loader.load(path, (gltf) => {
-          if (model) {
-            scene.remove(model);
-          }
-          model = gltf.scene;
-          model.traverse((child) => {
-            if (child.isMesh) {
-              const mat = new THREE.MeshPhysicalMaterial({
-                map: child.material.map,
-                roughness: params.roughness,
-                metalness: params.metalness,
-                clearcoat: params.clearcoat,
-                clearcoatRoughness: params.clearcoatRoughness,
-                specularIntensity: params.specularIntensity,
-                specularColor: new THREE.Color(params.specularColor),
-               sheenColor: new THREE.Color(params.sheenColor),
-               sheenRoughness: params.sheenRoughness,
-                anisotropy: params.anisotropy,
-                anisotropyRotation: params.anisotropyRotation,
-              });
-              child.material = mat;
+        console.log('Loading model', path);
+        loader.load(
+          path,
+          (gltf) => {
+            if (model) {
+              scene.remove(model);
             }
-          });
-          scene.add(model);
-          updateURL();
-        });
+            model = gltf.scene;
+            model.traverse((child) => {
+              if (child.isMesh) {
+                const mat = new THREE.MeshPhysicalMaterial({
+                  map: child.material.map,
+                  roughness: params.roughness,
+                  metalness: params.metalness,
+                  clearcoat: params.clearcoat,
+                  clearcoatRoughness: params.clearcoatRoughness,
+                  specularIntensity: params.specularIntensity,
+                  specularColor: new THREE.Color(params.specularColor),
+                 sheenColor: new THREE.Color(params.sheenColor),
+                 sheenRoughness: params.sheenRoughness,
+                  anisotropy: params.anisotropy,
+                  anisotropyRotation: params.anisotropyRotation,
+                });
+                child.material = mat;
+              }
+            });
+            scene.add(model);
+            updateURL();
+            console.log('Model loaded');
+          },
+          undefined,
+          (err) => {
+            console.error('Failed to load model', err);
+          },
+        );
+      }
       }
 
       function animate() {
@@ -306,18 +321,27 @@
       function applyTexture(file) {
         if (!file) return;
         const url = URL.createObjectURL(file);
-        textureLoader.load(url, (tex) => {
-          if (model) {
-            model.traverse((child) => {
-              if (child.isMesh) {
-                child.material.map = tex;
-                child.material.needsUpdate = true;
-              }
-            });
-          }
-          URL.revokeObjectURL(url);
-          updateMaterials();
-        });
+        console.log('Loading texture', file.name);
+        textureLoader.load(
+          url,
+          (tex) => {
+            if (model) {
+              model.traverse((child) => {
+                if (child.isMesh) {
+                  child.material.map = tex;
+                  child.material.needsUpdate = true;
+                }
+              });
+            }
+            URL.revokeObjectURL(url);
+            updateMaterials();
+            console.log('Texture applied');
+          },
+          undefined,
+          (err) => {
+            console.error('Failed to load texture', err);
+          },
+        );
       }
 
       // Prevent the browser from opening files when dropped outside the drop zone

--- a/tests/instructions.test.js
+++ b/tests/instructions.test.js
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+const html = fs.readFileSync('index.html', 'utf8');
+
+describe('instructions', () => {
+  it('mentions running a local server', () => {
+    const hasHint = /http\.server/.test(html);
+    expect(hasHint).toEqual(true);
+  });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -2,5 +2,6 @@ import './test-utils.js';
 import './utils.test.js';
 import './gltf.test.js';
 import './viewer.test.js';
+import './instructions.test.js';
 import { run } from './test-utils.js';
 await run();


### PR DESCRIPTION
## Summary
- document that users must serve the site via `python3 -m http.server`
- show instructions and developer console hint directly on the page
- log model and texture loading to the console
- test that instructions mention running a local server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68605b392b20832b8a484b3c2c788e31