### PR TITLE
Fix three import resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,8 +154,15 @@
         Copy Link<span class="help" data-tooltip="Copies a URL with your current settings so you can share your design">?</span>
       </button>
     </div>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://unpkg.com/three@0.158.0/build/three.module.js"
+        }
+      }
+    </script>
     <script type="module">
-      import * as THREE from "https://unpkg.com/three@0.158.0/build/three.module.js";
+      import * as THREE from "three";
       import { GLTFLoader } from "https://unpkg.com/three@0.158.0/examples/jsm/loaders/GLTFLoader.js";
       import { OrbitControls } from "https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js";
       import { buildQuery, debounce } from "./src/utils.js";

--- a/tests/importmap.test.js
+++ b/tests/importmap.test.js
@@ -1,0 +1,11 @@
+import fs from 'fs';
+
+const html = fs.readFileSync('index.html', 'utf8');
+
+describe('import map', () => {
+  it('defines mapping for three module', () => {
+    const regex = /<script type="importmap">[\s\S]*"three"\s*:\s*"https:\/\/unpkg.com\/three@[^"']*three.module.js"[\s\S]*<\/script>/;
+    const hasMap = regex.test(html);
+    expect(hasMap).toEqual(true);
+  });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -2,6 +2,7 @@ import './test-utils.js';
 import './utils.test.js';
 import './gltf.test.js';
 import './viewer.test.js';
+import './importmap.test.js';
 import './instructions.test.js';
 import './syntax.test.js';
 import { run } from './test-utils.js';


### PR DESCRIPTION
## Summary
- add import map so example loaders resolve the `three` module
- assert import map in regression test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686068182f24832ba87a26369e819cbd