### PR TITLE
Fix updateURL initialization order

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,6 +260,23 @@
           urlParams.get("anisotropyRotation"),
         );
 
+      const updateURL = debounce(() => {
+        const q = buildQuery({
+          model: params.model,
+          roughness: params.roughness,
+          metalness: params.metalness,
+          clearcoat: params.clearcoat,
+          clearcoatRoughness: params.clearcoatRoughness,
+          specularIntensity: params.specularIntensity,
+          specularColor: params.specularColor,
+          sheenColor: params.sheenColor,
+          sheenRoughness: params.sheenRoughness,
+          anisotropy: params.anisotropy,
+          anisotropyRotation: params.anisotropyRotation,
+        });
+        history.replaceState(null, "", `?${q}`);
+      }, 200);
+
       init();
       document.getElementById("modelSelect").value = params.model;
       document.getElementById("finishSelect").value = params.finish;
@@ -308,23 +325,6 @@
         camera.updateProjectionMatrix();
         renderer.setSize(container.clientWidth, container.clientHeight);
       }
-      const updateURL = debounce(() => {
-        const q = buildQuery({
-          model: params.model,
-          roughness: params.roughness,
-          metalness: params.metalness,
-          clearcoat: params.clearcoat,
-          clearcoatRoughness: params.clearcoatRoughness,
-          specularIntensity: params.specularIntensity,
-          specularColor: params.specularColor,
-          sheenColor: params.sheenColor,
-          sheenRoughness: params.sheenRoughness,
-          anisotropy: params.anisotropy,
-          anisotropyRotation: params.anisotropyRotation,
-        });
-        history.replaceState(null, "", `?${q}`);
-      }, 200);
-
       function loadModel(path) {
         if (["cube", "sphere", "cylinder"].includes(path)) {
           if (model) scene.remove(model);

--- a/tests/init-order.test.js
+++ b/tests/init-order.test.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+
+const html = fs.readFileSync('index.html', 'utf8');
+const match = html.match(/<script type="module">([\s\S]*?)<\/script>/);
+const script = match ? match[1] : '';
+
+describe('initialization order', () => {
+  it('declares updateURL before first loadModel call', () => {
+    const callIndex = script.indexOf('loadModel(params.model)');
+    const declIndex = script.indexOf('const updateURL');
+    expect(declIndex < callIndex).toEqual(true);
+  });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -5,5 +5,6 @@ import './viewer.test.js';
 import './importmap.test.js';
 import './instructions.test.js';
 import './syntax.test.js';
+import './init-order.test.js';
 import { run } from './test-utils.js';
 await run();


### PR DESCRIPTION
## Summary
- move `updateURL` definition before it's first used
- add regression test ensuring `updateURL` is declared before initial `loadModel` call

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68606f8bad08832b85ef628b32785c85