### PR TITLE
Add texture thumbnail preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,20 @@
         border-radius: 6px;
         transition: background 0.3s, border-color 0.3s;
         background: rgba(255, 255, 255, 0.6);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        overflow: hidden;
+      }
+      #dropArea img {
+        max-width: 100%;
+        max-height: 100%;
+        object-fit: contain;
+        display: none;
+        pointer-events: none;
+      }
+      #dropMessage {
+        display: block;
       }
       #dropArea.hover {
         background: #eef;
@@ -173,7 +187,8 @@
       <section>
         <h2>Texture<span class="help" data-tooltip="Upload a PNG or JPEG image to use as a texture. It will wrap onto the 3D plank.">?</span></h2>
         <div id="dropArea" aria-label="Drop texture" role="button">
-          Drag &amp; Drop Texture Here
+          <span id="dropMessage">Drag &amp; Drop Texture Here</span>
+          <img id="texturePreview" alt="texture preview" />
         </div>
         <input id="textureInput" type="file" accept="image/*" style="display:none" />
         <span class="help" data-tooltip="Drop an image file here and it will immediately show on the plank">?</span>
@@ -427,16 +442,26 @@
 
       const textureLoader = new THREE.TextureLoader();
       const dropArea = document.getElementById("dropArea");
+      const dropMessage = document.getElementById("dropMessage");
+      const preview = document.getElementById("texturePreview");
       const fileInput = document.getElementById("textureInput");
 
       let lastTextureName = '';
       let currentTexture = null;
-      dropArea.textContent = 'Drag & Drop Texture Here';
+      dropMessage.style.display = 'block';
+      preview.style.display = 'none';
 
       function applyTexture(file) {
         if (!file) return;
         const url = URL.createObjectURL(file);
+        const previewUrl = URL.createObjectURL(file);
         logEvent('Loading texture ' + file.name);
+        preview.src = previewUrl;
+        preview.style.display = 'block';
+        dropMessage.style.display = 'none';
+        preview.onload = () => {
+          URL.revokeObjectURL(previewUrl);
+        };
         textureLoader.load(
           url,
           (tex) => {
@@ -452,7 +477,6 @@
             URL.revokeObjectURL(url);
             updateMaterials();
             lastTextureName = file.name;
-            dropArea.textContent = file.name;
             logEvent('Texture applied to model');
           },
           undefined,


### PR DESCRIPTION
## Summary
- show dropped texture as an image thumbnail
- adjust drop area styles to constrain preview

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686073812960832b8234e39983d02e31