### PR TITLE
Improve viewer interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,6 @@
         left: 0;
         width: 100vw;
         height: 24px;
-        max-height: 50vh;
         overflow: hidden;
         z-index: 20;
       }
@@ -150,7 +149,7 @@
   </head>
   <body>
     <div id="viewer"></div>
-    <details id="eventViewer">
+    <details id="eventViewer" open>
       <summary>Event Log</summary>
       <div id="eventLog"></div>
     </details>
@@ -369,6 +368,18 @@
             model = gltf.scene;
             model.traverse((child) => {
               if (child.isMesh) {
+                // give paper-thin planks some thickness
+                const pos = child.geometry.attributes.position;
+                if (pos && pos.count === 4) {
+                  const box = new THREE.Box3().setFromBufferAttribute(pos);
+                  const w = box.max.x - box.min.x;
+                  const d = box.max.z - box.min.z;
+                  const thickness = 0.1;
+                  const geom = new THREE.BoxGeometry(w, thickness, d);
+                  geom.translate((box.max.x + box.min.x) / 2, thickness / 2, (box.max.z + box.min.z) / 2);
+                  child.geometry.dispose();
+                  child.geometry = geom;
+                }
                 const mat = new THREE.MeshPhysicalMaterial({
                   map: currentTexture || child.material.map,
                   roughness: params.roughness,
@@ -562,6 +573,7 @@
                   anisotropyRotation: params.anisotropyRotation,
                   side: THREE.DoubleSide,
                 });
+                child.material.needsUpdate = true;
               }
             });
           }
@@ -596,13 +608,8 @@
       function onDrag(e) {
         const diff = startY - e.clientY;
         const minH = evSummary.offsetHeight;
-        let h = Math.min(window.innerHeight * 0.8, Math.max(minH, startH + diff));
+        const h = Math.max(minH, startH + diff);
         ev.style.height = h + 'px';
-        if (h > minH + 5) {
-          ev.open = true;
-        } else {
-          ev.open = false;
-        }
       }
 
       function endDrag() {

--- a/tests/viewer.test.js
+++ b/tests/viewer.test.js
@@ -20,4 +20,14 @@ describe('viewer container', () => {
     const regex = /#eventViewer\s*{[^}]*position:\s*fixed;[^}]*bottom:\s*0;/;
     expect(regex.test(html)).toEqual(true);
   });
+
+  it('event viewer starts open', () => {
+    const hasOpen = /<details id="eventViewer"[^>]*open/.test(html);
+    expect(hasOpen).toEqual(true);
+  });
+
+  it('event viewer has no max-height limit', () => {
+    const regex = /#eventViewer\s*{[^}]*max-height:/;
+    expect(regex.test(html)).toEqual(false);
+  });
 });


### PR DESCRIPTION
## Summary
- keep event viewer open and allow dragging to any height
- update material changes to refresh three.js materials
- add thickness to plank models when loaded
- test for open event viewer and removed max-height rule

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686071cefaa0832bb5dc40a5cf27ed7a