### PR TITLE
Fix texture initialization order

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,8 @@
       });
 
       let scene, camera, renderer, controls, model;
+      let lastTextureName = '';
+      let currentTexture = null;
       const params = {
         model: "models/plank1.gltf",
         roughness: 0.5,
@@ -429,8 +431,6 @@
       const dropArea = document.getElementById("dropArea");
       const fileInput = document.getElementById("textureInput");
 
-      let lastTextureName = '';
-      let currentTexture = null;
       dropArea.textContent = 'Drag & Drop Texture Here';
 
       function applyTexture(file) {

--- a/tests/init-order.test.js
+++ b/tests/init-order.test.js
@@ -10,4 +10,10 @@ describe('initialization order', () => {
     const declIndex = script.indexOf('const updateURL');
     expect(declIndex < callIndex).toEqual(true);
   });
+
+  it('declares currentTexture before first loadModel call', () => {
+    const callIndex = script.indexOf('loadModel(params.model)');
+    const declIndex = script.indexOf('let currentTexture');
+    expect(declIndex < callIndex).toEqual(true);
+  });
 });


### PR DESCRIPTION
## Summary
- fix `currentTexture` variable hoisting issue
- add regression test for initialization order

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860740d3c44832ba002c4bba083fae6