### PR TITLE
Fix utils import path in main module

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { GLTFLoader } from "https://unpkg.com/three@0.158.0/examples/jsm/loaders/GLTFLoader.js";
 import { OrbitControls } from "https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js";
-import { buildQuery, debounce, logEvent } from "./src/utils.js";
+import { buildQuery, debounce, logEvent } from "./utils.js";
 import GUI from "https://cdn.jsdelivr.net/npm/lil-gui@0.18/+esm";
 
 

--- a/tests/main-import.test.js
+++ b/tests/main-import.test.js
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+const script = fs.readFileSync('src/main.js', 'utf8');
+
+describe('main imports', () => {
+  it('imports utils from same directory', () => {
+    const regex = /from\s+['"]\.\/utils.js['"]/;
+    expect(regex.test(script)).toEqual(true);
+  });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -4,6 +4,7 @@ import './gltf.test.js';
 import './viewer.test.js';
 import './importmap.test.js';
 import './instructions.test.js';
+import "./main-import.test.js";
 import './syntax.test.js';
 import './init-order.test.js';
 import { run } from './test-utils.js';


### PR DESCRIPTION
## Summary
- correct relative import path for utils
- add test for utils import path

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686078a1ea00832bba23c6726e056b30