### PR TITLE
Add material help and resizable log

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ npm run dev
 
 The application uses Vite for development. Run `npm run dev` and open <http://localhost:5173>. Share your current design simply by copying the browser URL, which encodes all parameters.
 
+## Material Parameters
+
+The viewer exposes a set of physical material properties. They can be adjusted
+through the on-page controls or by specifying them in the URL. Below is a quick
+reference for each parameter.
+
+| Parameter            | Description                                                        | Example                            |
+| -------------------- | ------------------------------------------------------------------ | ---------------------------------- |
+| `roughness`          | `0` gives a mirror-like finish, `1` results in a fully matte look. | `?roughness=0.2` for shiny varnish |
+| `metalness`          | `0` behaves like wood or plastic, `1` turns the surface metallic.  | `?metalness=1`                     |
+| `clearcoat`          | Strength of an extra transparent coat, useful for varnish.         | `?clearcoat=0.5`                   |
+| `clearcoatRoughness` | How glossy the clearcoat itself is.                                | `?clearcoatRoughness=0.1`          |
+| `specularIntensity`  | Scales the brightness of highlights.                               | `?specularIntensity=1.5`           |
+| `specularColor`      | Hex color used to tint highlights.                                 | `?specularColor=%23ffffff`         |
+| `sheenColor`         | Color of the fabric-like sheen effect.                             | `?sheenColor=%23ff8800`            |
+| `sheenRoughness`     | Roughness of the sheen component.                                  | `?sheenRoughness=0.6`              |
+| `anisotropy`         | Amount of directional reflection, simulating grain.                | `?anisotropy=0.8`                  |
+| `anisotropyRotation` | Rotation of the anisotropic direction (radians).                   | `?anisotropyRotation=1.57`         |
+
+You can combine these parameters in the query string to share a particular
+look. For example:
+
+```
+?roughness=0.2&clearcoat=0.7&anisotropy=0.5
+```
+
+will load the page with a shiny, varnished appearance that shows wood grain.
+
 ## Building for GitHub Pages
 
 To generate a static version of the site run:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Viewer from '../components/Viewer';
 import DropZone from '../components/DropZone';
 import FinishSelect from '../components/FinishSelect';
 import EventLog from '../components/EventLog';
+import ParamHelp from '../components/ParamHelp';
 import { buildQuery } from '../src/utils.js';
 import { useMaterialStore } from '../src/state';
 import { Leva, useControls } from 'leva';
@@ -115,7 +116,11 @@ export default function Page() {
       <div id="ui">
         <section>
           <h2>Model</h2>
-          <select id="modelSelect" value={model} onChange={(e) => set({ model: e.target.value })}>
+          <select
+            id="modelSelect"
+            value={model}
+            onChange={(e) => set({ model: e.target.value })}
+          >
             <option value="models/plank1.gltf">Plank 1</option>
             <option value="models/plank2.gltf">Plank 2</option>
             <option value="cube">Cube</option>
@@ -131,6 +136,7 @@ export default function Page() {
           <h2>Finish</h2>
           <FinishSelect value={finish} onChange={(v) => set({ finish: v })} />
         </section>
+        <ParamHelp />
       </div>
       <EventLog events={events} />
     </div>

--- a/components/EventLog.tsx
+++ b/components/EventLog.tsx
@@ -1,18 +1,48 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 type Props = {
   events: string[];
 };
 
 export default function EventLog({ events }: Props) {
+  const [height, setHeight] = useState(200);
+
+  const startDrag = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const startY = e.clientY;
+      const startHeight = height;
+      const onMove = (ev: MouseEvent) => {
+        const diff = startY - ev.clientY;
+        setHeight(Math.max(50, startHeight + diff));
+      };
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [height],
+  );
+
   return (
-    <details id="eventViewer" open style={{ position: 'fixed', bottom: 0 }}>
-      <summary>Event Log</summary>
-      <div id="eventLog" style={{ maxHeight: 200, overflowY: 'auto' }}>
+    <div
+      id="eventViewer"
+      style={{ position: 'fixed', bottom: 0, left: 0, right: 0 }}
+    >
+      <div
+        onMouseDown={startDrag}
+        style={{ height: 6, cursor: 'ns-resize', background: '#ccc' }}
+      />
+      <div
+        id="eventLog"
+        style={{ height, overflowY: 'auto', background: 'white' }}
+      >
         {events.map((e, i) => (
           <div key={i}>{e}</div>
         ))}
       </div>
-    </details>
+    </div>
   );
 }

--- a/components/ParamHelp.tsx
+++ b/components/ParamHelp.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+export default function ParamHelp() {
+  return (
+    <details id="paramHelp" style={{ maxWidth: 400 }}>
+      <summary>Material Parameter Help</summary>
+      <ul>
+        <li>
+          <strong>roughness</strong> – 0 is mirror smooth, 1 is completely
+          matte.
+        </li>
+        <li>
+          <strong>metalness</strong> – 0 behaves like plastic/wood, 1 is a metal
+          surface.
+        </li>
+        <li>
+          <strong>clearcoat</strong> – strength of a transparent varnish layer.
+        </li>
+        <li>
+          <strong>clearcoatRoughness</strong> – roughness of that varnish layer.
+        </li>
+        <li>
+          <strong>specularIntensity</strong> – brightness of the specular
+          highlight.
+        </li>
+        <li>
+          <strong>specularColor</strong> – tint color of reflections.
+        </li>
+        <li>
+          <strong>sheenColor</strong> – color used for fabric-like sheen.
+        </li>
+        <li>
+          <strong>sheenRoughness</strong> – how sharp the sheen highlight is.
+        </li>
+        <li>
+          <strong>anisotropy</strong> – amount of directional reflection, as in
+          brushed metal or wood grain.
+        </li>
+        <li>
+          <strong>anisotropyRotation</strong> – rotation of that anisotropic
+          direction in radians.
+        </li>
+      </ul>
+    </details>
+  );
+}

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -22,7 +22,16 @@ function checkScriptSyntax() {
 }
 
 checkFile('src/utils.js');
-['components/Viewer.tsx', 'components/DropZone.tsx', 'components/FinishSelect.tsx', 'components/EventLog.tsx', 'app/page.tsx', 'src/state.ts', 'src/main.tsx'].forEach(f => {
+[
+  'components/Viewer.tsx',
+  'components/DropZone.tsx',
+  'components/FinishSelect.tsx',
+  'components/EventLog.tsx',
+  'components/ParamHelp.tsx',
+  'app/page.tsx',
+  'src/state.ts',
+  'src/main.tsx',
+].forEach((f) => {
   if (fs.existsSync(f)) checkFile(f);
 });
 checkScriptSyntax();


### PR DESCRIPTION
## Summary
- document material parameters in README
- add on-page help for material parameters
- make event log height draggable and always open
- include new component in lint script

## Testing
- `node scripts/lint.js`
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6860f5cb9b70832ba8758ea85e510409