### PR TITLE
Fix workflow cache error

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
       - run: npm install
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@
 
 ## 6. CI / Build Steps
 - GitHub Actions builds and deploys the site to GitHub Pages on every push to
-  `main`. The workflow installs dependencies, runs `npm run build`, and
-  publishes the `dist/` directory.
+  `main`. The workflow installs dependencies using Node 20 without caching,
+  runs `npm run build`, and publishes the `dist/` directory.
 - Run `npm run dev` for local development. Do not commit files from `dist/`.
 
 ## 6a. Postmortems


### PR DESCRIPTION
## Summary
- disable npm cache option in GitHub workflow
- document the change in `AGENTS.md`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686134432e98832ba8589c0090a3c4e9