### PR TITLE
Fix invalid drei version and document dependency checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@
 - Use the helper script `scripts/commit.sh` when committing. It runs
   `npm test` and `npm run lint` and aborts the commit if either fails.
 - Ensure all tests pass before pushing code.
+- When modifying dependencies, verify the specified version exists with
+  `npm info <name>@<version>` before committing.
 
 ## 4. Linting / Static Checks
 - Run `npm run lint` which executes `node scripts/lint.js` followed by ESLint.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ npm install
 npm run dev
 ```
 
+When adding or updating dependencies, verify the package version exists using:
+
+```bash
+npm info <name>@<version>
+```
+
 The application uses Vite for development. Run `npm run dev` and open <http://localhost:5173>. Share your current design simply by copying the browser URL, which encodes all parameters.
 
 ## Material Parameters

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "@react-three/fiber": "9.7.5",
-    "@react-three/drei": "9.86.7",
+    "@react-three/drei": "9.86.6",
     "zustand": "4.3.9",
     "leva": "0.9.37"
   },

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -10,4 +10,8 @@ describe('package config', () => {
   it('defines build script', () => {
     expect(typeof (pkg.scripts && pkg.scripts.build)).toEqual('string');
   });
+
+  it('pins drei to a published version', () => {
+    expect(pkg.dependencies['@react-three/drei']).toEqual('9.86.6');
+  });
 });


### PR DESCRIPTION
## Summary
- use @react-three/drei 9.86.6 so npm install succeeds
- add instructions in README and AGENTS to verify package versions
- add regression test ensuring drei version stays pinned

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861375c9644832b9660b8aeef45d399