### PR TITLE
Fix drei dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "@react-three/fiber": "9.7.5",
-    "@react-three/drei": "9.86.6",
+    "@react-three/drei": "0.9.7",
     "zustand": "4.3.9",
     "leva": "0.9.37"
   },

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -12,6 +12,6 @@ describe('package config', () => {
   });
 
   it('pins drei to a published version', () => {
-    expect(pkg.dependencies['@react-three/drei']).toEqual('9.86.6');
+    expect(pkg.dependencies['@react-three/drei']).toEqual('0.9.7');
   });
 });


### PR DESCRIPTION
## Summary
- update `@react-three/drei` to a valid version
- adjust package test for new version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68613c1ce21c832bbf35e49983be9039