### PR TITLE
Update drei dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "@react-three/fiber": "9.7.5",
-    "@react-three/drei": "0.9.7",
+    "@react-three/drei": "9.99.7",
     "zustand": "4.3.9",
     "leva": "0.9.37"
   },

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -4,7 +4,9 @@ const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
 describe('package config', () => {
   it('includes next dependency', () => {
-    expect(typeof (pkg.dependencies && pkg.dependencies.next)).toEqual('string');
+    expect(typeof (pkg.dependencies && pkg.dependencies.next)).toEqual(
+      'string',
+    );
   });
 
   it('defines build script', () => {
@@ -12,6 +14,6 @@ describe('package config', () => {
   });
 
   it('pins drei to a published version', () => {
-    expect(pkg.dependencies['@react-three/drei']).toEqual('0.9.7');
+    expect(pkg.dependencies['@react-three/drei']).toEqual('9.99.7');
   });
 });


### PR DESCRIPTION
## Summary
- use a newer version of `@react-three/drei`
- update unit test expectation

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68613ffd2e1c832b92a3c37434b290af