### PR TITLE
Fix npm install by pinning valid three.js dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@react-three/fiber": "9.7.5",
-    "@react-three/drei": "9.99.7",
+    "@react-three/fiber": "8.17.12",
+    "@react-three/drei": "9.122.0",
     "zustand": "4.3.9",
-    "leva": "0.9.37"
+    "leva": "0.9.36"
   },
   "devDependencies": {
     "typescript": "5.2.2",

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -14,6 +14,6 @@ describe('package config', () => {
   });
 
   it('pins drei to a published version', () => {
-    expect(pkg.dependencies['@react-three/drei']).toEqual('9.99.7');
+    expect(pkg.dependencies['@react-three/drei']).toEqual('9.122.0');
   });
 });


### PR DESCRIPTION
## Summary
- update `@react-three/fiber` and `@react-three/drei` to published versions
- fix `package.test.js` expectation for drei version
- correct invalid `leva` version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686144db5788832bb7b49baa5a26b1d3