### PR TITLE
Restore texture upload and model selection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -130,7 +130,12 @@ export default function Page() {
         </section>
         <section>
           <h2>Texture</h2>
-          <DropZone onFile={(f) => logEvent('Loaded texture ' + f.name)} />
+          <DropZone
+            onFile={(f) => {
+              set({ texture: URL.createObjectURL(f) });
+              logEvent('Loaded texture ' + f.name);
+            }}
+          />
         </section>
         <section>
           <h2>Finish</h2>

--- a/components/Viewer.tsx
+++ b/components/Viewer.tsx
@@ -1,11 +1,113 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
+import { useMaterialStore } from '../src/state';
+import {
+  BoxGeometry,
+  SphereGeometry,
+  CylinderGeometry,
+  Mesh,
+  MeshPhysicalMaterial,
+  TextureLoader,
+  Color,
+  DoubleSide,
+  Object3D,
+} from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+function Model() {
+  const {
+    model,
+    texture,
+    roughness,
+    metalness,
+    clearcoat,
+    clearcoatRoughness,
+    specularIntensity,
+    specularColor,
+    sheenColor,
+    sheenRoughness,
+    anisotropy,
+    anisotropyRotation,
+  } = useMaterialStore();
+
+  const [object, setObject] = useState<Object3D | null>(null);
+  const [tex, setTex] = useState<THREE.Texture | null>(null);
+
+  useEffect(() => {
+    if (!texture) {
+      setTex(null);
+      return;
+    }
+    const loader = new TextureLoader();
+    loader.load(texture, (t) => setTex(t));
+  }, [texture]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (model === 'cube' || model === 'sphere' || model === 'cylinder') {
+      let geometry;
+      if (model === 'cube') geometry = new BoxGeometry();
+      else if (model === 'sphere') geometry = new SphereGeometry(1, 32, 16);
+      else geometry = new CylinderGeometry(1, 1, 2, 32);
+      const mesh = new Mesh(geometry);
+      setObject(mesh);
+      return () => {};
+    }
+    const loader = new GLTFLoader();
+    loader.load(model, (gltf) => {
+      if (!cancelled) setObject(gltf.scene);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [model]);
+
+  useEffect(() => {
+    if (!object) return;
+    const params = {
+      roughness,
+      metalness,
+      clearcoat,
+      clearcoatRoughness,
+      specularIntensity,
+      specularColor: new Color(specularColor),
+      sheenColor: new Color(sheenColor),
+      sheenRoughness,
+      anisotropy,
+      anisotropyRotation,
+      side: DoubleSide,
+      map: tex || null,
+    };
+    object.traverse((child: any) => {
+      if (child.isMesh) {
+        child.material = new MeshPhysicalMaterial(params);
+      }
+    });
+  }, [
+    object,
+    tex,
+    roughness,
+    metalness,
+    clearcoat,
+    clearcoatRoughness,
+    specularIntensity,
+    specularColor,
+    sheenColor,
+    sheenRoughness,
+    anisotropy,
+    anisotropyRotation,
+  ]);
+
+  if (!object) return null;
+  return <primitive object={object} />;
+}
 
 export default function Viewer() {
   return (
     <Canvas style={{ width: '100vw', height: '100vh' }}>
       <ambientLight intensity={0.8} />
+      <Model />
       <OrbitControls makeDefault />
     </Canvas>
   );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "18.2.0",
     "@react-three/fiber": "8.17.12",
     "@react-three/drei": "9.122.0",
+    "three": "0.158.0",
     "zustand": "4.3.9",
     "leva": "0.9.36"
   },

--- a/src/state.ts
+++ b/src/state.ts
@@ -13,6 +13,7 @@ export interface MaterialState {
   sheenRoughness: number;
   anisotropy: number;
   anisotropyRotation: number;
+  texture: string | null;
   set(values: Partial<MaterialState>): void;
 }
 
@@ -29,5 +30,6 @@ export const useMaterialStore = create<MaterialState>((set) => ({
   sheenRoughness: 0.5,
   anisotropy: 0,
   anisotropyRotation: 0,
+  texture: (null),
   set: (values) => set(values),
 }));

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -26,4 +26,10 @@ describe('material store', () => {
     useMaterialStore.getState().set({ roughness: 0.25 });
     expect(useMaterialStore.getState().roughness).toEqual(0.25);
   });
+
+  it('stores texture url', () => {
+    expect(useMaterialStore.getState().texture).toEqual(null);
+    useMaterialStore.getState().set({ texture: 'foo.png' });
+    expect(useMaterialStore.getState().texture).toEqual('foo.png');
+  });
 });


### PR DESCRIPTION
## Summary
- add Three.js as a dependency
- store uploaded texture URL in the zustand store
- allow users to pick a texture file when uploading
- load 3D models and textures in the viewer
- test that the texture field works

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68619d504088832baacdac0ed0eb6489