### PR TITLE
Fix event log overlay height

### DIFF
--- a/components/EventLog.tsx
+++ b/components/EventLog.tsx
@@ -14,7 +14,8 @@ export default function EventLog({ events }: Props) {
       const startHeight = height;
       const onMove = (ev: MouseEvent) => {
         const diff = startY - ev.clientY;
-        setHeight(Math.max(50, startHeight + diff));
+        const maxHeight = window.innerHeight * 0.5;
+        setHeight(Math.min(maxHeight, Math.max(50, startHeight + diff)));
       };
       const onUp = () => {
         window.removeEventListener('mousemove', onMove);


### PR DESCRIPTION
## Summary
- prevent EventLog overlay from growing past half the viewport

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861a4a58c4c832b825422c919df412b