### PR TITLE
Make left toolbox draggable

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import DropZone from '../components/DropZone';
 import FinishSelect from '../components/FinishSelect';
 import EventLog from '../components/EventLog';
 import ParamHelp from '../components/ParamHelp';
+import Panel from '../components/Panel';
 import { buildQuery } from '../src/utils.js';
 import { useMaterialStore } from '../src/state';
 import { Leva, useControls } from 'leva';
@@ -113,7 +114,7 @@ export default function Page() {
     <div>
       <Viewer />
       <Leva collapsed />
-      <div id="ui">
+      <Panel id="ui" title="Settings">
         <section>
           <h2>Model</h2>
           <select
@@ -142,7 +143,7 @@ export default function Page() {
           <FinishSelect value={finish} onChange={(v) => set({ finish: v })} />
         </section>
         <ParamHelp />
-      </div>
+      </Panel>
       <EventLog events={events} />
     </div>
   );

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -1,0 +1,48 @@
+import React, { useState, useRef, useCallback } from 'react';
+
+type PanelProps = {
+  id?: string;
+  title: string;
+  children: React.ReactNode;
+};
+
+export default function Panel({ id, title, children }: PanelProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const start = useRef<{ x: number; y: number } | null>(null);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      start.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+      const onMove = (ev: MouseEvent) => {
+        if (!start.current) return;
+        setPos({
+          x: ev.clientX - start.current.x,
+          y: ev.clientY - start.current.y,
+        });
+      };
+      const onUp = () => {
+        start.current = null;
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [pos],
+  );
+
+  return (
+    <div
+      id={id}
+      className={`panel${collapsed ? ' collapsed' : ''}`}
+      style={{ left: pos.x, top: pos.y }}
+    >
+      <div className="panel-title" onMouseDown={onMouseDown}>
+        <span className="drag-dots">•••••</span>
+        <button onClick={() => setCollapsed(!collapsed)}>{title}</button>
+      </div>
+      <div className="panel-body">{children}</div>
+    </div>
+  );
+}

--- a/style.css
+++ b/style.css
@@ -7,15 +7,42 @@ body {
 
 #ui {
   position: fixed;
-  top: 0;
-  left: 0;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
+}
+
+.panel {
+  position: absolute;
+  width: 280px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, 'Roboto Mono', monospace;
+  color: #fefefe;
+  background: #292d39;
+  box-shadow: 0 0 9px 0 #00000088;
+  border-radius: 10px;
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  background: #292d39;
+  user-select: none;
+  cursor: move;
+}
+
+.drag-dots {
+  margin-right: 6px;
+  cursor: grab;
+}
+
+.panel-body {
+  background: #181c20;
   padding: 10px;
-  max-width: 300px;
-  background: rgba(255, 255, 255, 0.9);
-  z-index: 1;
-  backdrop-filter: blur(4px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border-bottom-right-radius: 4px;
+}
+
+.collapsed .panel-body {
+  display: none;
 }
 
 .viewerCanvas {


### PR DESCRIPTION
## Summary
- add reusable `Panel` component for draggable/collapsible panels
- style the panel to match Leva's look
- wrap existing upload/model UI in the new panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861a6b254f0832bbb40705125e67901