### PR TITLE
Fix viewer canvas height on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wooden Design</title>
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure styles load when deployed under `/wooden-design/`
- switch paths in `index.html` to relative so the viewer canvas fills the screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861acff9290832bb97211038bb6d087