### PR TITLE
Fix canvas size issue

### DIFF
--- a/components/Viewer.tsx
+++ b/components/Viewer.tsx
@@ -105,7 +105,10 @@ function Model() {
 
 export default function Viewer() {
   return (
-    <Canvas className="viewerCanvas">
+    <Canvas
+      className="viewerCanvas"
+      style={{ width: '100vw', height: '100vh', display: 'block' }}
+    >
       <ambientLight intensity={0.8} />
       <Model />
       <OrbitControls makeDefault />

--- a/style.css
+++ b/style.css
@@ -1,3 +1,9 @@
+html,
+body,
+#root {
+  height: 100%;
+}
+
 body {
   margin: 0;
   font-family: Arial, Helvetica, sans-serif;

--- a/tests/style.test.js
+++ b/tests/style.test.js
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+const css = fs.readFileSync('style.css', 'utf8');
+
+describe('style.css', () => {
+  it('sets full-page height', () => {
+    const rule = /html,\nbody,\n#root \{\n  height: 100%;\n\}/m;
+    expect(rule.test(css)).toEqual(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the root page elements fill the viewport
- add inline sizing style to the Canvas component
- test that style.css defines full-page height

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861b2f95a50832b81bfe7093e612c02