### PR TITLE
Update settings toolbox UI

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import Viewer from '../components/Viewer';
 import DropZone from '../components/DropZone';
 import FinishSelect from '../components/FinishSelect';
 import EventLog from '../components/EventLog';
-import ParamHelp from '../components/ParamHelp';
 import Panel from '../components/Panel';
 import { buildQuery } from '../src/utils.js';
 import { useMaterialStore } from '../src/state';
@@ -115,8 +114,10 @@ export default function Page() {
       <Viewer />
       <Leva collapsed />
       <Panel id="ui" title="Settings">
-        <section>
-          <h2>Model</h2>
+        <section className="option-row">
+          <label htmlFor="modelSelect" className="option-label">
+            Model
+          </label>
           <select
             id="modelSelect"
             value={model}
@@ -129,20 +130,18 @@ export default function Page() {
             <option value="cylinder">Cylinder</option>
           </select>
         </section>
-        <section>
-          <h2>Texture</h2>
-          <DropZone
-            onFile={(f) => {
-              set({ texture: URL.createObjectURL(f) });
-              logEvent('Loaded texture ' + f.name);
-            }}
-          />
-        </section>
-        <section>
-          <h2>Finish</h2>
+        <section className="option-row">
+          <label htmlFor="finishSelect" className="option-label">
+            Finish
+          </label>
           <FinishSelect value={finish} onChange={(v) => set({ finish: v })} />
         </section>
-        <ParamHelp />
+        <DropZone
+          onFile={(f) => {
+            set({ texture: URL.createObjectURL(f) });
+            logEvent('Loaded texture ' + f.name);
+          }}
+        />
       </Panel>
       <EventLog events={events} />
     </div>

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -12,7 +12,7 @@ export default function Panel({ id, title, children }: PanelProps) {
   const start = useRef<{ x: number; y: number } | null>(null);
 
   const onMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: React.MouseEvent<HTMLSpanElement>) => {
       start.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
       const onMove = (ev: MouseEvent) => {
         if (!start.current) return;
@@ -38,9 +38,17 @@ export default function Panel({ id, title, children }: PanelProps) {
       className={`panel${collapsed ? ' collapsed' : ''}`}
       style={{ left: pos.x, top: pos.y }}
     >
-      <div className="panel-title" onMouseDown={onMouseDown}>
-        <span className="drag-dots">•••••</span>
-        <button onClick={() => setCollapsed(!collapsed)}>{title}</button>
+      <div className="panel-title">
+        <button
+          className="collapse-btn"
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          <span className="collapse-icon">{collapsed ? '▸' : '▾'}</span>
+          {title}
+        </button>
+        <span className="drag-dots" onMouseDown={onMouseDown}>
+          ⋮⋮
+        </span>
       </div>
       <div className="panel-body">{children}</div>
     </div>

--- a/style.css
+++ b/style.css
@@ -30,16 +30,30 @@ body {
 }
 
 .panel-title {
+  position: relative;
   display: flex;
   align-items: center;
   padding: 4px 8px;
   background: #292d39;
   user-select: none;
-  cursor: move;
+}
+
+.collapse-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
 }
 
 .drag-dots {
-  margin-right: 6px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
   cursor: grab;
 }
 
@@ -119,6 +133,19 @@ body {
   overflow-y: auto;
 }
 
-#paramHelp {
-  max-width: 400px;
+.option-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.option-label {
+  font-size: 11px;
+  color: #fefefe;
+  font-family: inherit;
+}
+
+.option-row select {
+  margin-left: auto;
 }


### PR DESCRIPTION
## Summary
- drop unused Material Parameter Help
- style Settings panel header with a collapse arrow and centered drag handle
- align model and finish selectors with option labels
- move texture upload below other controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861ba9f555c832b8876e215d35734f9