### PR TITLE
Update left toolbox styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -113,7 +113,7 @@ export default function Page() {
     <div>
       <Viewer />
       <Leva collapsed />
-      <Panel id="ui" title="Settings">
+      <Panel id="ui" title="">
         <section className="option-row">
           <label htmlFor="modelSelect" className="option-label">
             Model

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -47,7 +47,14 @@ export default function Panel({ id, title, children }: PanelProps) {
           {title}
         </button>
         <span className="drag-dots" onMouseDown={onMouseDown}>
-          ⋮⋮
+          <svg width="20" height="10" viewBox="0 0 28 14">
+            <circle cx="2" cy="2" r="2" />
+            <circle cx="14" cy="2" r="2" />
+            <circle cx="26" cy="2" r="2" />
+            <circle cx="2" cy="12" r="2" />
+            <circle cx="14" cy="12" r="2" />
+            <circle cx="26" cy="12" r="2" />
+          </svg>
         </span>
       </div>
       <div className="panel-body">{children}</div>

--- a/style.css
+++ b/style.css
@@ -36,6 +36,8 @@ body {
   padding: 4px 8px;
   background: #292d39;
   user-select: none;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
 }
 
 .collapse-btn {
@@ -55,6 +57,9 @@ body {
   left: 50%;
   transform: translateX(-50%);
   cursor: grab;
+  fill: #535760;
+  height: 10px;
+  width: 20px;
 }
 
 .panel-body {
@@ -75,17 +80,17 @@ body {
 
 .panel select:focus,
 .panel input:focus,
-.panel button:focus {
+.panel button:not(.collapse-btn):focus {
   outline: none;
   border-color: #007bff;
 }
 
-.panel button {
+.panel button:not(.collapse-btn) {
   background: #007bff;
   cursor: pointer;
 }
 
-.panel button:hover {
+.panel button:not(.collapse-btn):hover {
   background: #3c93ff;
 }
 


### PR DESCRIPTION
## Summary
- tweak Panel component's drag handle SVG
- align left toolbox styles with the Leva panel
- remove "Settings" label from Panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861c0310d30832b836176f8640d1915