### PR TITLE
Fix finish preset behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,7 +42,7 @@ export default function Page() {
     history.replaceState(null, '', '?' + q);
   }, [model, finish]);
 
-  useControls({
+  const [, setCtrl] = useControls(() => ({
     roughness: {
       value: roughness,
       min: 0,
@@ -107,7 +107,20 @@ export default function Page() {
       step: 0.01,
       onChange: (v: number) => set({ anisotropyRotation: v }),
     },
-  });
+  }));
+
+  useEffect(() => {
+    if (finish === 'matte') {
+      set({ roughness: 0.9, metalness: 0 });
+      setCtrl({ roughness: 0.9, metalness: 0 });
+    } else if (finish === 'satin') {
+      set({ roughness: 0.5, metalness: 0 });
+      setCtrl({ roughness: 0.5, metalness: 0 });
+    } else if (finish === 'gloss') {
+      set({ roughness: 0.1, metalness: 0 });
+      setCtrl({ roughness: 0.1, metalness: 0 });
+    }
+  }, [finish, set, setCtrl]);
 
   return (
     <div>

--- a/tests/finish.test.js
+++ b/tests/finish.test.js
@@ -1,0 +1,14 @@
+import fs from 'fs';
+const code = fs.readFileSync('app/page.tsx', 'utf8');
+
+describe('finish presets', () => {
+  it('handles matte preset', () => {
+    expect(/finish === 'matte'/.test(code)).toEqual(true);
+  });
+  it('handles satin preset', () => {
+    expect(/finish === 'satin'/.test(code)).toEqual(true);
+  });
+  it('handles gloss preset', () => {
+    expect(/finish === 'gloss'/.test(code)).toEqual(true);
+  });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -8,6 +8,7 @@ import './main-import.test.js';
 import './syntax.test.js';
 import './init-order.test.js';
 import './state.test.js';
+import './finish.test.js';
 import './html.test.js';
 import { run } from './test-utils.js';
 await run();


### PR DESCRIPTION
## Summary
- update `Page` component with a `useEffect` that applies finish presets
- allow programmatic update of Leva controls
- add regression test for finish presets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861c412809c832bbc88aea3e981a4b1