### PR TITLE
Update finish preset behavior and UI styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,64 +48,64 @@ export default function Page() {
       min: 0,
       max: 1,
       step: 0.01,
-      onChange: (v: number) => set({ roughness: v }),
+      onChange: (v: number) => set({ roughness: v, finish: 'custom' }),
     },
     metalness: {
       value: metalness,
       min: 0,
       max: 1,
       step: 0.01,
-      onChange: (v: number) => set({ metalness: v }),
+      onChange: (v: number) => set({ metalness: v, finish: 'custom' }),
     },
     clearcoat: {
       value: clearcoat,
       min: 0,
       max: 1,
       step: 0.01,
-      onChange: (v: number) => set({ clearcoat: v }),
+      onChange: (v: number) => set({ clearcoat: v, finish: 'custom' }),
     },
     clearcoatRoughness: {
       value: clearcoatRoughness,
       min: 0,
       max: 1,
       step: 0.01,
-      onChange: (v: number) => set({ clearcoatRoughness: v }),
+      onChange: (v: number) => set({ clearcoatRoughness: v, finish: 'custom' }),
     },
     specularIntensity: {
       value: specularIntensity,
       min: 0,
       max: 2,
       step: 0.01,
-      onChange: (v: number) => set({ specularIntensity: v }),
+      onChange: (v: number) => set({ specularIntensity: v, finish: 'custom' }),
     },
     specularColor: {
       value: specularColor,
-      onChange: (v: string) => set({ specularColor: v }),
+      onChange: (v: string) => set({ specularColor: v, finish: 'custom' }),
     },
     sheenColor: {
       value: sheenColor,
-      onChange: (v: string) => set({ sheenColor: v }),
+      onChange: (v: string) => set({ sheenColor: v, finish: 'custom' }),
     },
     sheenRoughness: {
       value: sheenRoughness,
       min: 0,
       max: 1,
       step: 0.01,
-      onChange: (v: number) => set({ sheenRoughness: v }),
+      onChange: (v: number) => set({ sheenRoughness: v, finish: 'custom' }),
     },
     anisotropy: {
       value: anisotropy,
       min: 0,
       max: 1,
       step: 0.01,
-      onChange: (v: number) => set({ anisotropy: v }),
+      onChange: (v: number) => set({ anisotropy: v, finish: 'custom' }),
     },
     anisotropyRotation: {
       value: anisotropyRotation,
       min: 0,
       max: Math.PI * 2,
       step: 0.01,
-      onChange: (v: number) => set({ anisotropyRotation: v }),
+      onChange: (v: number) => set({ anisotropyRotation: v, finish: 'custom' }),
     },
   }));
 
@@ -129,7 +129,7 @@ export default function Page() {
       <Panel id="ui" title="">
         <section className="option-row">
           <label htmlFor="modelSelect" className="option-label">
-            Model
+            model
           </label>
           <select
             id="modelSelect"
@@ -145,7 +145,7 @@ export default function Page() {
         </section>
         <section className="option-row">
           <label htmlFor="finishSelect" className="option-label">
-            Finish
+            finish
           </label>
           <FinishSelect value={finish} onChange={(v) => set({ finish: v })} />
         </section>

--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -25,7 +25,7 @@ export default function DropZone({ onFile }: Props) {
       }}
       onClick={() => inputRef.current?.click()}
     >
-      Drag & Drop Texture Here
+      drag & drop texture here
       <input
         ref={inputRef}
         type="file"

--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@ body {
   width: 280px;
   font-family: ui-monospace, SFMono-Regular, Menlo, 'Roboto Mono', monospace;
   font-size: 11px;
-  color: #fefefe;
+  color: #8c92a4;
   background: #292d39;
   box-shadow: 0 0 9px 0 #00000088;
   border-radius: 10px;
@@ -71,7 +71,7 @@ body {
 .panel input,
 .panel button {
   font: inherit;
-  color: #fefefe;
+  color: #8c92a4;
   background: #373c4b;
   border: 1px solid #535760;
   border-radius: 3px;
@@ -109,7 +109,7 @@ body {
   padding: 20px;
   border-radius: 4px;
   background: #373c4b;
-  color: #fefefe;
+  color: #8c92a4;
   cursor: pointer;
   text-align: center;
 }
@@ -147,7 +147,7 @@ body {
 
 .option-label {
   font-size: 11px;
-  color: #fefefe;
+  color: #8c92a4;
   font-family: inherit;
 }
 


### PR DESCRIPTION
## Summary
- when parameter sliders are changed, switch finish preset to `custom`
- make left-hand toolbox text lowercase
- match left-hand toolbox text color with Leva controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861c7bf2748832b899d059a59695d5c