### PR TITLE
Add ParamHelp panel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import DropZone from '../components/DropZone';
 import FinishSelect from '../components/FinishSelect';
 import EventLog from '../components/EventLog';
 import Panel from '../components/Panel';
+import ParamHelp from '../components/ParamHelp';
 import { buildQuery } from '../src/utils.js';
 import { useMaterialStore } from '../src/state';
 import { Leva, useControls } from 'leva';
@@ -41,13 +42,9 @@ export default function Page() {
     if (params.get('clearcoat'))
       obj.clearcoat = parseFloat(params.get('clearcoat')!);
     if (params.get('clearcoatRoughness'))
-      obj.clearcoatRoughness = parseFloat(
-        params.get('clearcoatRoughness')!,
-      );
+      obj.clearcoatRoughness = parseFloat(params.get('clearcoatRoughness')!);
     if (params.get('specularIntensity'))
-      obj.specularIntensity = parseFloat(
-        params.get('specularIntensity')!,
-      );
+      obj.specularIntensity = parseFloat(params.get('specularIntensity')!);
     if (params.get('specularColor'))
       obj.specularColor = params.get('specularColor');
     if (params.get('sheenColor')) obj.sheenColor = params.get('sheenColor');
@@ -56,9 +53,7 @@ export default function Page() {
     if (params.get('anisotropy'))
       obj.anisotropy = parseFloat(params.get('anisotropy')!);
     if (params.get('anisotropyRotation'))
-      obj.anisotropyRotation = parseFloat(
-        params.get('anisotropyRotation')!,
-      );
+      obj.anisotropyRotation = parseFloat(params.get('anisotropyRotation')!);
     if (params.get('texture')) obj.texture = params.get('texture');
     set(obj);
   }, [set]);
@@ -207,6 +202,7 @@ export default function Page() {
             logEvent('Loaded texture ' + f.name);
           }}
         />
+        <ParamHelp />
       </Panel>
       <EventLog events={events} />
     </div>

--- a/tests/param-help.test.js
+++ b/tests/param-help.test.js
@@ -1,0 +1,15 @@
+import fs from 'fs';
+
+const code = fs.readFileSync('app/page.tsx', 'utf8');
+
+describe('ParamHelp integration', () => {
+  it('imports ParamHelp component', () => {
+    expect(
+      /import ParamHelp from '\.\.\/components\/ParamHelp'/.test(code),
+    ).toEqual(true);
+  });
+
+  it('renders ParamHelp element', () => {
+    expect(/<ParamHelp \/>/.test(code)).toEqual(true);
+  });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -9,6 +9,7 @@ import './syntax.test.js';
 import './init-order.test.js';
 import './state.test.js';
 import './finish.test.js';
+import './param-help.test.js';
 import './html.test.js';
 import './url.test.js';
 import { run } from './test-utils.js';


### PR DESCRIPTION
## Summary
- import `ParamHelp` in `app/page.tsx`
- render `ParamHelp` within the main panel
- add tests verifying `ParamHelp` is imported and used

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68623db7d234832bbc0625d11f64a39a