### PR TITLE
Add help page and accessibility updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,31 +43,8 @@ The application uses Vite for development. Run `npm run dev` and open <http://lo
 
 ## Material Parameters
 
-The viewer exposes a set of physical material properties. They can be adjusted
-through the on-page controls or by specifying them in the URL. Below is a quick
-reference for each parameter.
-
-| Parameter            | Description                                                        | Example                            |
-| -------------------- | ------------------------------------------------------------------ | ---------------------------------- |
-| `roughness`          | `0` gives a mirror-like finish, `1` results in a fully matte look. | `?roughness=0.2` for shiny varnish |
-| `metalness`          | `0` behaves like wood or plastic, `1` turns the surface metallic.  | `?metalness=1`                     |
-| `clearcoat`          | Strength of an extra transparent coat, useful for varnish.         | `?clearcoat=0.5`                   |
-| `clearcoatRoughness` | How glossy the clearcoat itself is.                                | `?clearcoatRoughness=0.1`          |
-| `specularIntensity`  | Scales the brightness of highlights.                               | `?specularIntensity=1.5`           |
-| `specularColor`      | Hex color used to tint highlights.                                 | `?specularColor=%23ffffff`         |
-| `sheenColor`         | Color of the fabric-like sheen effect.                             | `?sheenColor=%23ff8800`            |
-| `sheenRoughness`     | Roughness of the sheen component.                                  | `?sheenRoughness=0.6`              |
-| `anisotropy`         | Amount of directional reflection, simulating grain.                | `?anisotropy=0.8`                  |
-| `anisotropyRotation` | Rotation of the anisotropic direction (radians).                   | `?anisotropyRotation=1.57`         |
-
-You can combine these parameters in the query string to share a particular
-look. For example:
-
-```
-?roughness=0.2&clearcoat=0.7&anisotropy=0.5
-```
-
-will load the page with a shiny, varnished appearance that shows wood grain.
+The application supports a variety of physical material properties. A full description of each option is available on the [help page](./help).
+Parameters can be tweaked through the interface or included in the URL to share a specific look.
 
 ## Building for GitHub Pages
 

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,17 +1,13 @@
-import React from 'react';
-
-export default function ParamHelp() {
+export default function HelpPage() {
   return (
-    <details id="paramHelp">
-      <summary>Material Parameter Help</summary>
+    <main>
+      <h1>Material Parameter Help</h1>
       <ul>
         <li>
-          <strong>roughness</strong> – 0 is mirror smooth, 1 is completely
-          matte.
+          <strong>roughness</strong> – 0 is mirror smooth, 1 is completely matte.
         </li>
         <li>
-          <strong>metalness</strong> – 0 behaves like plastic/wood, 1 is a metal
-          surface.
+          <strong>metalness</strong> – 0 behaves like plastic/wood, 1 is a metal surface.
         </li>
         <li>
           <strong>clearcoat</strong> – strength of a transparent varnish layer.
@@ -20,8 +16,7 @@ export default function ParamHelp() {
           <strong>clearcoatRoughness</strong> – roughness of that varnish layer.
         </li>
         <li>
-          <strong>specularIntensity</strong> – brightness of the specular
-          highlight.
+          <strong>specularIntensity</strong> – brightness of the specular highlight.
         </li>
         <li>
           <strong>specularColor</strong> – tint color of reflections.
@@ -33,14 +28,12 @@ export default function ParamHelp() {
           <strong>sheenRoughness</strong> – how sharp the sheen highlight is.
         </li>
         <li>
-          <strong>anisotropy</strong> – amount of directional reflection, as in
-          brushed metal or wood grain.
+          <strong>anisotropy</strong> – amount of directional reflection, as in brushed metal or wood grain.
         </li>
         <li>
-          <strong>anisotropyRotation</strong> – rotation of that anisotropic
-          direction in radians.
+          <strong>anisotropyRotation</strong> – rotation of that anisotropic direction in radians.
         </li>
       </ul>
-    </details>
+    </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import DropZone from '../components/DropZone';
 import FinishSelect from '../components/FinishSelect';
 import EventLog from '../components/EventLog';
 import Panel from '../components/Panel';
-import ParamHelp from '../components/ParamHelp';
 import { buildQuery } from '../src/utils.js';
 import { useMaterialStore } from '../src/state';
 import { Leva, useControls } from 'leva';
@@ -202,7 +201,9 @@ export default function Page() {
             logEvent('Loaded texture ' + f.name);
           }}
         />
-        <ParamHelp />
+        <a href="/help" className="help-link">
+          material parameter help
+        </a>
       </Panel>
       <EventLog events={events} />
     </div>

--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -16,6 +16,7 @@ export default function DropZone({ onFile }: Props) {
     <div
       id="dropArea"
       className="dropArea"
+      aria-label="Texture upload drop zone"
       onDragOver={(e) => {
         e.preventDefault();
       }}
@@ -31,6 +32,7 @@ export default function DropZone({ onFile }: Props) {
         type="file"
         accept="image/*"
         className="fileInput"
+        aria-label="Upload texture image"
         onChange={(e) => handleFiles(e.target.files)}
       />
     </div>

--- a/components/EventLog.tsx
+++ b/components/EventLog.tsx
@@ -29,7 +29,11 @@ export default function EventLog({ events }: Props) {
 
   return (
     <div id="eventViewer">
-      <div className="drag-handle" onMouseDown={startDrag} />
+      <div
+        className="drag-handle"
+        aria-label="Resize log"
+        onMouseDown={startDrag}
+      />
       <div id="eventLog" style={{ height }}>
         {events.map((e, i) => (
           <div key={i}>{e}</div>

--- a/components/FinishSelect.tsx
+++ b/components/FinishSelect.tsx
@@ -9,9 +9,16 @@ const presets = ['custom', 'matte', 'satin', 'gloss'];
 
 export default function FinishSelect({ value, onChange }: Props) {
   return (
-    <select id="finishSelect" value={value} onChange={(e) => onChange(e.target.value)}>
+    <select
+      id="finishSelect"
+      value={value}
+      aria-label="Finish preset"
+      onChange={(e) => onChange(e.target.value)}
+    >
       {presets.map((p) => (
-        <option key={p} value={p}>{p[0].toUpperCase() + p.slice(1)}</option>
+        <option key={p} value={p}>
+          {p[0].toUpperCase() + p.slice(1)}
+        </option>
       ))}
     </select>
   );

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -41,12 +41,17 @@ export default function Panel({ id, title, children }: PanelProps) {
       <div className="panel-title">
         <button
           className="collapse-btn"
+          aria-label="Toggle panel"
           onClick={() => setCollapsed(!collapsed)}
         >
           <span className="collapse-icon">{collapsed ? '▸' : '▾'}</span>
           {title}
         </button>
-        <span className="drag-dots" onMouseDown={onMouseDown}>
+        <span
+          className="drag-dots"
+          aria-label="Drag panel"
+          onMouseDown={onMouseDown}
+        >
           <svg width="20" height="10" viewBox="0 0 28 14">
             <circle cx="2" cy="2" r="2" />
             <circle cx="14" cy="2" r="2" />

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -27,7 +27,6 @@ checkFile('src/utils.js');
   'components/DropZone.tsx',
   'components/FinishSelect.tsx',
   'components/EventLog.tsx',
-  'components/ParamHelp.tsx',
   'app/page.tsx',
   'src/state.ts',
   'src/main.tsx',

--- a/tests/param-help.test.js
+++ b/tests/param-help.test.js
@@ -2,14 +2,8 @@ import fs from 'fs';
 
 const code = fs.readFileSync('app/page.tsx', 'utf8');
 
-describe('ParamHelp integration', () => {
-  it('imports ParamHelp component', () => {
-    expect(
-      /import ParamHelp from '\.\.\/components\/ParamHelp'/.test(code),
-    ).toEqual(true);
-  });
-
-  it('renders ParamHelp element', () => {
-    expect(/<ParamHelp \/>/.test(code)).toEqual(true);
+describe('help link', () => {
+  it('links to help page', () => {
+    expect(/href="\/help"/.test(code)).toEqual(true);
   });
 });


### PR DESCRIPTION
## Summary
- move `ParamHelp` content to new route `app/help/page.tsx`
- link help page from the main UI and remove old component
- update README to reference the help page
- add `aria-label` attributes to interactive controls
- adjust linter target and tests for new page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68624661a8b4832bb0e7a1dba2fe1580