### PR TITLE
Fix help link path and add menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The application uses Vite for development. Run `npm run dev` and open <http://lo
 
 ## Material Parameters
 
-The application supports a variety of physical material properties. A full description of each option is available on the [help page](./help).
+The application supports a variety of physical material properties. A full description of each option is available on the [help page](./help/), accessible from the menu in the top-right corner of the app.
 Parameters can be tweaked through the interface or included in the URL to share a specific look.
 
 ## Building for GitHub Pages

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -171,6 +171,14 @@ export default function Page() {
   return (
     <div>
       <Viewer />
+      <details className="menu">
+        <summary>menu</summary>
+        <ul>
+          <li>
+            <a href="./help/">material parameter help</a>
+          </li>
+        </ul>
+      </details>
       <Leva collapsed />
       <Panel id="ui" title="">
         <section className="option-row">
@@ -201,9 +209,6 @@ export default function Page() {
             logEvent('Loaded texture ' + f.name);
           }}
         />
-        <a href="/help" className="help-link">
-          material parameter help
-        </a>
       </Panel>
       <EventLog events={events} />
     </div>

--- a/style.css
+++ b/style.css
@@ -154,3 +154,42 @@ body {
 .option-row select {
   margin-left: auto;
 }
+
+.menu {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  font-family: ui-monospace, SFMono-Regular, Menlo, 'Roboto Mono', monospace;
+  font-size: 11px;
+  color: #8c92a4;
+}
+
+.menu summary {
+  cursor: pointer;
+  background: #292d39;
+  padding: 4px 8px;
+  border-radius: 4px;
+  user-select: none;
+}
+
+.menu[open] {
+  background: #292d39;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.menu a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.menu a:hover {
+  text-decoration: underline;
+}

--- a/tests/param-help.test.js
+++ b/tests/param-help.test.js
@@ -4,6 +4,6 @@ const code = fs.readFileSync('app/page.tsx', 'utf8');
 
 describe('help link', () => {
   it('links to help page', () => {
-    expect(/href="\/help"/.test(code)).toEqual(true);
+    expect(/href="\.\/help\//.test(code)).toEqual(true);
   });
 });


### PR DESCRIPTION
## Summary
- move help link out of the toolbox and into a new drop-down menu
- correct link path so GitHub Pages can resolve it
- update styles for the menu
- note menu location in README
- update help link test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68624b799d7c832bb4917fcb5ff40850