### PR TITLE
Fix help page build and dropdown overlay

### DIFF
--- a/help/index.html
+++ b/help/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Material Parameter Help</title>
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="../src/help.tsx"></script>
+  </body>
+</html>

--- a/src/help.tsx
+++ b/src/help.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import HelpPage from '../app/help/page';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <HelpPage />
+  </React.StrictMode>,
+);

--- a/style.css
+++ b/style.css
@@ -159,7 +159,7 @@ body {
   position: fixed;
   top: 10px;
   right: 10px;
-  z-index: 1000;
+  z-index: 1101;
   font-family: ui-monospace, SFMono-Regular, Menlo, 'Roboto Mono', monospace;
   font-size: 11px;
   color: #8c92a4;

--- a/tests/help-page.test.js
+++ b/tests/help-page.test.js
@@ -1,0 +1,7 @@
+import fs from 'fs';
+
+describe('help page html', () => {
+  it('has help/index.html', () => {
+    expect(fs.existsSync('help/index.html')).toEqual(true);
+  });
+});

--- a/tests/run.js
+++ b/tests/run.js
@@ -10,6 +10,7 @@ import './init-order.test.js';
 import './state.test.js';
 import './finish.test.js';
 import './param-help.test.js';
+import './help-page.test.js';
 import './html.test.js';
 import './url.test.js';
 import { run } from './test-utils.js';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   base: '/wooden-design/',
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        help: resolve(__dirname, 'help/index.html'),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- raise z-index of help menu so it isn't hidden by toolbox
- add a dedicated help page entrypoint
- build help page with Vite
- include test for presence of help page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68624f114e34832bab3d26b40181c169